### PR TITLE
fix(prowlarr): send categories as repeated query params

### DIFF
--- a/backend/internal/acquisition/prowlarr.go
+++ b/backend/internal/acquisition/prowlarr.go
@@ -122,7 +122,9 @@ func (c *ProwlarrClient) searchOnce(ctx context.Context, queryText string, forma
 	values := url.Values{}
 	values.Set("query", strings.TrimSpace(queryText))
 	values.Set("type", "search")
-	values.Set("categories", categoriesForFormat(format))
+	for _, category := range categoryListForFormat(format) {
+		values.Add("categories", category)
+	}
 
 	endpoint := "/api/v1/search?" + values.Encode()
 	req, err := c.request(ctx, http.MethodGet, endpoint, nil)
@@ -678,6 +680,20 @@ func categoriesForFormat(format string) string {
 	default:
 		return "7000"
 	}
+}
+
+// categoryListForFormat returns the same categories as categoriesForFormat, but
+// split for use with url.Values.Add. Prowlarr's /api/v1/search binds categories
+// as an array of int, which requires a repeated query parameter
+// (categories=7000&categories=3030). A single comma-joined value fails model
+// binding with 400 Bad Request. The Newznab feed endpoint still wants the
+// comma-joined "cat" form, so categoriesForFormat is kept for that caller.
+func categoryListForFormat(format string) []string {
+	categories := categoriesForFormat(format)
+	if categories == "" {
+		return nil
+	}
+	return strings.Split(categories, ",")
 }
 
 func releaseID(values ...string) string {

--- a/backend/internal/acquisition/prowlarr_test.go
+++ b/backend/internal/acquisition/prowlarr_test.go
@@ -162,8 +162,8 @@ func TestProwlarrSearchTriesISBNBeforeTitleAndDeduplicates(t *testing.T) {
 			t.Fatalf("expected api key header, got %q", r.Header.Get("X-Api-Key"))
 		}
 		queries = append(queries, r.URL.Query().Get("query"))
-		if r.URL.Query().Get("categories") != "7000" {
-			t.Fatalf("expected ebook category, got %q", r.URL.Query().Get("categories"))
+		if got := r.URL.Query()["categories"]; strings.Join(got, "|") != "7000" {
+			t.Fatalf("expected ebook category, got %#v", got)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Query().Get("query") {
@@ -209,5 +209,33 @@ func TestCategoriesForAnyFormatIncludeAudiobooks(t *testing.T) {
 	}
 	if got := categoriesForFormat(""); got != "7000,3030" {
 		t.Fatalf("expected empty format to include book and audiobook categories, got %q", got)
+	}
+}
+
+func TestProwlarrSearchSendsRepeatedCategoryParamsForAudiobooks(t *testing.T) {
+	var categories []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Prowlarr binds categories as an array of int; a comma-joined value
+		// fails model binding with 400 Bad Request, so each category must be
+		// sent as its own query parameter.
+		if raw := r.URL.RawQuery; strings.Contains(raw, "categories=7000%2C3030") {
+			t.Fatalf("categories were comma-joined into one parameter: %s", raw)
+		}
+		categories = r.URL.Query()["categories"]
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	client := NewProwlarrClient(server.URL, "test-key", server.Client())
+	if _, err := client.Search(context.Background(), ReleaseSearchQuery{
+		Query:  "The Hobbit",
+		Format: "audiobook",
+		Limit:  10,
+	}); err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+	if strings.Join(categories, "|") != "7000|3030" {
+		t.Fatalf("expected separate audiobook categories, got %#v", categories)
 	}
 }


### PR DESCRIPTION
## Symptom

Ebook searches work. Audiobook searches always return HTTP 502, on every
query term and every indexer, with no user-visible setting that differs
between the two:

```
POST /api/v1/releases/search  {"query":"the hobbit","format":"audiobook",...}
-> 502  {"error":"prowlarr search returned 400 Bad Request"}
```

## Root cause

`ProwlarrClient.searchOnce` (`backend/internal/acquisition/prowlarr.go`)
built the category parameter with `url.Values.Set` and a comma-joined
string from `categoriesForFormat`:

| format             | value       | encodes to               | result |
| ------------------ | ----------- | ------------------------ | ------ |
| `ebook` / `book`   | `7000`      | `categories=7000`        | 200    |
| `audiobook`/`audio`| `7000,3030` | `categories=7000%2C3030` | **400** |
| `""` / `any`       | `7000,3030` | `categories=7000%2C3030` | **400** |

Prowlarr's `/api/v1/search` binds `categories` as an array of int, which
in ASP.NET means a *repeated* parameter, not a comma-separated string.
It rejects the comma-joined form during model binding:

```json
"categories": {
  "rawValue": "7000,3030",
  "errors": [{ "errorMessage": "The value '7000,3030' is not valid." }],
  "validationState": "invalid"
}
```

Librarry surfaces that upstream 400 to the browser as a 502.

Ebook searches were unaffected only incidentally: a single category has
no comma to mis-encode.

Confirmed against Prowlarr directly (same query, same indexers):

```
categories=7000%2C3030          -> 400
categories=7000&categories=3030 -> 200
categories=7020                 -> 200
```

## Fix

Add `categoryListForFormat`, which splits the same list so each category
is appended with `url.Values.Add`, producing repeated parameters.

`categoriesForFormat` is deliberately retained: `fetchIndexerFeed` uses
it for the Newznab feed endpoint, where a comma-joined `cat` parameter
*is* the correct convention. Only the Prowlarr JSON search path changed.

## Verification

- `go build ./...` — clean
- `go test ./...` — all pass, no regressions
- New regression test `TestProwlarrSearchSendsRepeatedCategoryParamsForAudiobooks`
  fails without the fix (`categories were comma-joined into one parameter`)
  and passes with it
- `gofmt` clean; patch applies cleanly to pristine upstream at the above revision